### PR TITLE
Updates Sashimi versions to include Azure bundled tools warnings

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -19,11 +19,11 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="12.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="13.3.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -16,16 +16,16 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="19.2.0" />
-    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.0" />
-    <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
+    <PackageReference Include="Calamari.Common" Version="19.2.5" />
+    <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
+    <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="Microsoft.DotNet.Analyzers.Compatibility" Version="0.2.12-alpha">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="SharpCompress" Version="0.26.0" />
+    <PackageReference Include="SharpCompress" Version="0.28.2" />
   </ItemGroup>
 
 </Project>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -12,11 +12,11 @@
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="nunit" Version="3.13.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="13.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="13.1.0" />
+    <PackageReference Include="nunit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="13.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="13.0.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="4.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.1.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="13.1.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="13.1.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.3.0" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="13.3.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.2.0" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.3.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="4.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.0.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="13.0.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="13.0.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.1.0" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="13.1.0" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.1.2" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR updates to use the latest Sashimi versions so as to include changes from https://github.com/OctopusDeploy/Sashimi.AzureScripting/pull/10