### PR TITLE
Bump to `Calamari.Common@19.4.6`

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="13.3.0" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="13.3.1" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -16,7 +16,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="19.2.5" />
+    <PackageReference Include="Calamari.Common" Version="19.4.6" />
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.0" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="13.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="4.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.3.0" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="13.3.0" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="13.2.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="13.3.0" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="13.3.1" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="13.3.1" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="13.2.1" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="13.3.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Overview

This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Change: OctopusDeploy/Calamari#754

Issue: OctopusDeploy/Issues#6941