### PR TITLE
Revert to default Azure environment when no environment by name is found

### DIFF
--- a/source/Calamari/Azure/AzureClient.cs
+++ b/source/Calamari/Azure/AzureClient.cs
@@ -19,7 +19,7 @@ namespace Calamari.Azure
                 .Authenticate(
                     SdkContext.AzureCredentialsFactory.FromServicePrincipal(servicePrincipal.ClientId,
                         servicePrincipal.Password, servicePrincipal.TenantId,
-                        GetAzureEnvironment(servicePrincipal.AzureEnvironment)
+                        GetAzureEnvironment(new AzureKnownEnvironment(servicePrincipal.AzureEnvironment))
                     ))
                 .WithSubscription(servicePrincipal.SubscriptionNumber);
         }

--- a/source/Calamari/Azure/AzureClient.cs
+++ b/source/Calamari/Azure/AzureClient.cs
@@ -1,4 +1,3 @@
-using System;
 using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 
@@ -8,18 +7,11 @@ namespace Calamari.Azure
     {
         public static IAzure CreateAzureClient(this ServicePrincipalAccount servicePrincipal)
         {
-            AzureEnvironment GetAzureEnvironment(AzureKnownEnvironment environment)
-            {
-                return !string.IsNullOrEmpty(environment.Value)
-                    ? AzureEnvironment.FromName(environment.Value) ?? throw new InvalidOperationException($"Unknown environment name {environment.Value}")
-                    : AzureEnvironment.AzureGlobalCloud;
-            }
-
             return Microsoft.Azure.Management.Fluent.Azure.Configure()
                 .Authenticate(
                     SdkContext.AzureCredentialsFactory.FromServicePrincipal(servicePrincipal.ClientId,
                         servicePrincipal.Password, servicePrincipal.TenantId,
-                        GetAzureEnvironment(new AzureKnownEnvironment(servicePrincipal.AzureEnvironment))
+                        new AzureKnownEnvironment(servicePrincipal.AzureEnvironment).AsAzureSDKEnvironment()
                     ))
                 .WithSubscription(servicePrincipal.SubscriptionNumber);
         }

--- a/source/Calamari/Azure/AzureClient.cs
+++ b/source/Calamari/Azure/AzureClient.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 
@@ -7,10 +8,10 @@ namespace Calamari.Azure
     {
         public static IAzure CreateAzureClient(this ServicePrincipalAccount servicePrincipal)
         {
-            AzureEnvironment GetAzureEnvironment(string environmentName)
+            AzureEnvironment GetAzureEnvironment(AzureKnownEnvironment environment)
             {
-                return !string.IsNullOrEmpty(environmentName)
-                    ? AzureEnvironment.FromName(environmentName) ?? AzureEnvironment.AzureGlobalCloud
+                return !string.IsNullOrEmpty(environment.Value)
+                    ? AzureEnvironment.FromName(environment.Value) ?? throw new InvalidOperationException($"Unknown environment name {environment.Value}")
                     : AzureEnvironment.AzureGlobalCloud;
             }
 

--- a/source/Calamari/Azure/AzureClient.cs
+++ b/source/Calamari/Azure/AzureClient.cs
@@ -7,13 +7,19 @@ namespace Calamari.Azure
     {
         public static IAzure CreateAzureClient(this ServicePrincipalAccount servicePrincipal)
         {
+            AzureEnvironment GetAzureEnvironment(string environmentName)
+            {
+                return !string.IsNullOrEmpty(environmentName)
+                    ? AzureEnvironment.FromName(environmentName) ?? AzureEnvironment.AzureGlobalCloud
+                    : AzureEnvironment.AzureGlobalCloud;
+            }
+
             return Microsoft.Azure.Management.Fluent.Azure.Configure()
                 .Authenticate(
                     SdkContext.AzureCredentialsFactory.FromServicePrincipal(servicePrincipal.ClientId,
                         servicePrincipal.Password, servicePrincipal.TenantId,
-                        !string.IsNullOrEmpty(servicePrincipal.AzureEnvironment)
-                            ? AzureEnvironment.FromName(servicePrincipal.AzureEnvironment)
-                            : AzureEnvironment.AzureGlobalCloud))
+                        GetAzureEnvironment(servicePrincipal.AzureEnvironment)
+                    ))
                 .WithSubscription(servicePrincipal.SubscriptionNumber);
         }
     }

--- a/source/Calamari/Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari/Azure/AzureKnownEnvironment.cs
@@ -1,0 +1,31 @@
+﻿namespace Calamari.Azure
+{
+    public sealed class AzureKnownEnvironment
+    {
+        private AzureKnownEnvironment(string value)
+        {
+            Value = value;
+        }
+
+        public string Value { get; }
+
+        public static readonly AzureKnownEnvironment Global = new AzureKnownEnvironment("AzureGlobalCloud");
+        public static readonly AzureKnownEnvironment AzureChinaCloud = new AzureKnownEnvironment("AzureChinaCloud");
+        public static readonly AzureKnownEnvironment AzureUSGovernment = new AzureKnownEnvironment("AzureUSGovernment");
+        public static readonly AzureKnownEnvironment AzureGermanCloud = new AzureKnownEnvironment("AzureGermanCloud");
+        
+        public static implicit operator AzureKnownEnvironment(string environment)
+        {
+            if (environment == Global.Value || environment == "AzureCloud") // this environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
+                return Global;
+            if (environment == AzureChinaCloud.Value)
+                return AzureChinaCloud;
+            if (environment == AzureUSGovernment.Value)
+                return AzureUSGovernment;
+            if (environment == AzureGermanCloud.Value)
+                return AzureGermanCloud;
+
+            return new AzureKnownEnvironment(environment);
+        }
+    }
+}

--- a/source/Calamari/Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari/Azure/AzureKnownEnvironment.cs
@@ -16,8 +16,8 @@
         
         public static implicit operator AzureKnownEnvironment(string environment)
         {
-            if (environment == Global.Value || environment == "AzureCloud") // this environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
-                return Global;
+            if (environment == Global.Value || environment == "AzureCloud") // This environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
+                return Global;                                              // We interpret it as the normal Azure environment for historical reasons
             if (environment == AzureChinaCloud.Value)
                 return AzureChinaCloud;
             if (environment == AzureUSGovernment.Value)

--- a/source/Calamari/Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari/Azure/AzureKnownEnvironment.cs
@@ -1,10 +1,16 @@
 ﻿namespace Calamari.Azure
 {
     public sealed class AzureKnownEnvironment
-    {
-        private AzureKnownEnvironment(string value)
+    { 
+        /// <param name="environment">The environment name exactly matching the names defined in Azure SDK (see here https://github.com/Azure/azure-libraries-for-net/blob/master/src/ResourceManagement/ResourceManager/AzureEnvironment.cs)
+        /// Other names are allowed in case this list is ever expanded/changed, but will likely result in an error at deployment time.
+        /// </param>
+        public AzureKnownEnvironment(string environment)
         {
-            Value = value;
+            Value = environment;
+            
+            if (environment == "AzureCloud") // This environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
+                Value = Global.Value;        // We interpret it as the normal Azure environment for historical reasons)
         }
 
         public string Value { get; }
@@ -13,19 +19,5 @@
         public static readonly AzureKnownEnvironment AzureChinaCloud = new AzureKnownEnvironment("AzureChinaCloud");
         public static readonly AzureKnownEnvironment AzureUSGovernment = new AzureKnownEnvironment("AzureUSGovernment");
         public static readonly AzureKnownEnvironment AzureGermanCloud = new AzureKnownEnvironment("AzureGermanCloud");
-        
-        public static implicit operator AzureKnownEnvironment(string environment)
-        {
-            if (environment == Global.Value || environment == "AzureCloud") // This environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
-                return Global;                                              // We interpret it as the normal Azure environment for historical reasons
-            if (environment == AzureChinaCloud.Value)
-                return AzureChinaCloud;
-            if (environment == AzureUSGovernment.Value)
-                return AzureUSGovernment;
-            if (environment == AzureGermanCloud.Value)
-                return AzureGermanCloud;
-
-            return new AzureKnownEnvironment(environment);
-        }
     }
 }

--- a/source/Calamari/Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari/Azure/AzureKnownEnvironment.cs
@@ -1,4 +1,7 @@
-﻿namespace Calamari.Azure
+﻿using System;
+using Microsoft.Azure.Management.ResourceManager.Fluent;
+
+namespace Calamari.Azure
 {
     public sealed class AzureKnownEnvironment
     { 
@@ -9,15 +12,24 @@
         {
             Value = environment;
             
-            if (environment == "AzureCloud") // This environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
-                Value = Global.Value;        // We interpret it as the normal Azure environment for historical reasons)
+            if (string.IsNullOrEmpty(environment) || environment == "AzureCloud") // This environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
+                Value = Global.Value;                                             // We interpret it as the normal Azure environment for historical reasons)
+
+            azureEnvironment = AzureEnvironment.FromName(Value) ??
+                               throw new InvalidOperationException($"Unknown environment name {Value}");
         }
 
+        private readonly AzureEnvironment azureEnvironment;
         public string Value { get; }
 
         public static readonly AzureKnownEnvironment Global = new AzureKnownEnvironment("AzureGlobalCloud");
         public static readonly AzureKnownEnvironment AzureChinaCloud = new AzureKnownEnvironment("AzureChinaCloud");
         public static readonly AzureKnownEnvironment AzureUSGovernment = new AzureKnownEnvironment("AzureUSGovernment");
         public static readonly AzureKnownEnvironment AzureGermanCloud = new AzureKnownEnvironment("AzureGermanCloud");
+
+        public AzureEnvironment AsAzureSDKEnvironment()
+        {
+            return azureEnvironment;
+        }
     }
 }

--- a/source/Calamari/Azure/ServicePrincipalAccount.cs
+++ b/source/Calamari/Azure/ServicePrincipalAccount.cs
@@ -18,8 +18,7 @@ namespace Calamari.Azure
             ResourceManagementEndpointBaseUri = variables.Get(AccountVariables.ResourceManagementEndPoint, DefaultVariables.ResourceManagementEndpoint);
             ActiveDirectoryEndpointBaseUri = variables.Get(AccountVariables.ActiveDirectoryEndPoint, DefaultVariables.ActiveDirectoryEndpoint);
         }
-
-        public string WhereHasMyStringGone { get; set; }
+        
         public string SubscriptionNumber { get; set; }
 
         public string ClientId { get; set; }


### PR DESCRIPTION
Fixes the issue mentioned [here](https://help.octopus.com/t/azure-application-services-health-check-failes/27036/4) where ticking the checkbox "Configure isolated Azure Connection" selects Global environment by default, due to a conversion happening in [Sashimi](https://github.com/OctopusDeploy/Sashimi/blob/14.0.1/source/Sashimi.Azure.Accounts/Web/AzureEnvironmentsListAction.cs#L47-L59) for global environment name.

Fixes https://github.com/OctopusDeploy/Issues/issues/6989