### PR TITLE
Use publishing profile deployment URL instead of constructing it manually

### DIFF
--- a/source/Calamari/Auth.cs
+++ b/source/Calamari/Auth.cs
@@ -1,38 +1,37 @@
 ﻿using System;
-using System.IO;
-using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.Xml.Linq;
 using Calamari.Azure;
-using Microsoft.Azure.Management.WebSites;
-using Microsoft.Azure.Management.WebSites.Models;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using Microsoft.Rest;
 
 namespace Calamari.AzureAppService
 {
-    class Auth
+    internal class Auth
     {
-        public static async Task<string> GetBasicAuthCreds(ServicePrincipalAccount principalAccount, TargetSite targetSite)
+        public static async Task<string> GetBasicAuthCreds(ServicePrincipalAccount principalAccount,
+            TargetSite targetSite)
         {
-            var (username, password) = await GetPublishProfileCredsAsync(targetSite, principalAccount);
-            var credential = Convert.ToBase64String(Encoding.ASCII.GetBytes($"{username}:{password}"));
+            var publishingProfile = await PublishingProfile.GetPublishingProfile(targetSite, principalAccount);
+            string credential =
+                Convert.ToBase64String(
+                    Encoding.ASCII.GetBytes($"{publishingProfile.Username}:{publishingProfile.Password}"));
             return credential;
         }
 
         public static async Task<string> GetAuthTokenAsync(ServicePrincipalAccount principalAccount)
         {
-            var authContext = GetContextUri(principalAccount.ActiveDirectoryEndpointBaseUri, principalAccount.TenantId);
+            string authContext =
+                GetContextUri(principalAccount.ActiveDirectoryEndpointBaseUri, principalAccount.TenantId);
             var context = new AuthenticationContext(authContext);
-            var result = await context.AcquireTokenAsync(principalAccount.ResourceManagementEndpointBaseUri, new ClientCredential(principalAccount.ClientId, principalAccount.Password));
+            var result = await context.AcquireTokenAsync(principalAccount.ResourceManagementEndpointBaseUri,
+                new ClientCredential(principalAccount.ClientId, principalAccount.Password));
             return result.AccessToken;
         }
 
         public static async Task<string> GetAuthTokenAsync(string ADEndpointBaseUri, string resourceMgmtEndpointBaseUri,
             string tenantId, string clientId, string clientSecret)
         {
-            var authContext = GetContextUri(ADEndpointBaseUri, tenantId);
+            string authContext = GetContextUri(ADEndpointBaseUri, tenantId);
             var context = new AuthenticationContext(authContext);
             var result = await context.AcquireTokenAsync(resourceMgmtEndpointBaseUri,
                 new ClientCredential(clientId, clientSecret));
@@ -41,49 +40,8 @@ namespace Calamari.AzureAppService
 
         private static string GetContextUri(string activeDirectoryEndPoint, string tenantId)
         {
-            if (!activeDirectoryEndPoint.EndsWith("/"))
-            {
-                return $"{activeDirectoryEndPoint}/{tenantId}";
-            }
+            if (!activeDirectoryEndPoint.EndsWith("/")) return $"{activeDirectoryEndPoint}/{tenantId}";
             return $"{activeDirectoryEndPoint}{tenantId}";
-        }
-        private static async Task<(string Username, string Password)> GetPublishProfileCredsAsync(TargetSite targetSite, ServicePrincipalAccount account)
-        {
-            var mgmtEndpoint = account.ResourceManagementEndpointBaseUri;
-            var token = await GetAuthTokenAsync(account);
-
-            var webAppClient = new WebSiteManagementClient(new Uri(mgmtEndpoint), new TokenCredentials(token))
-            { SubscriptionId = account.SubscriptionNumber };
-
-            var options = new CsmPublishingProfileOptions { Format = "WebDeploy" };
-            
-            webAppClient.WebApps.Get(targetSite.ResourceGroupName, targetSite.Site);
-
-            using var publishProfileStream = targetSite.HasSlot
-                ? await webAppClient.WebApps.ListPublishingProfileXmlWithSecretsSlotAsync(targetSite.ResourceGroupName,
-                    targetSite.Site, options, targetSite.Slot)
-                : await webAppClient.WebApps.ListPublishingProfileXmlWithSecretsAsync(targetSite.ResourceGroupName, targetSite.Site,
-                    options);
-
-            using var streamReader = new StreamReader(publishProfileStream);
-            var document = XDocument.Parse(await streamReader.ReadToEndAsync());
-
-            var profile = (from el in document.Descendants("publishProfile")
-                           where string.Compare(el.Attribute("publishMethod")?.Value, "MSDeploy", StringComparison.OrdinalIgnoreCase) == 0
-                           select new
-                           {
-                               PublishUrl = $"https://{el.Attribute("publishUrl")?.Value}",
-                               Username = el.Attribute("userName")?.Value,
-                               Password = el.Attribute("userPWD")?.Value,
-                               Site = el.Attribute("msdeploySite")?.Value
-                           }).FirstOrDefault();
-
-            if (profile == null)
-            {
-                throw new Exception("Failed to retrieve publishing profile.");
-            }
-
-            return (profile.Username, profile.Password);
         }
     }
 }

--- a/source/Calamari/Behaviors/AzureAppServiceBehaviour.cs
+++ b/source/Calamari/Behaviors/AzureAppServiceBehaviour.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -14,22 +13,22 @@ using Calamari.Common.Plumbing.Logging;
 using Calamari.Common.Plumbing.Pipeline;
 using Calamari.Common.Plumbing.Variables;
 using Microsoft.Azure.Management.AppService.Fluent;
-using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Rest;
+using WebSiteManagementClient = Microsoft.Azure.Management.WebSites.WebSiteManagementClient;
 
 namespace Calamari.AzureAppService.Behaviors
 {
-    class AzureAppServiceBehaviour : IDeployBehaviour
+    internal class AzureAppServiceBehaviour : IDeployBehaviour
     {
-        private ILog Log { get; }
-
-        private IPackageProvider Archive { get; set; }
-
         public AzureAppServiceBehaviour(ILog log)
         {
             Log = log;
             Archive = new ZipPackageProvider();
         }
+
+        private ILog Log { get; }
+
+        private IPackageProvider Archive { get; set; }
 
         public bool IsEnabled(RunningDeployment context)
         {
@@ -40,13 +39,13 @@ namespace Calamari.AzureAppService.Behaviors
         {
             var variables = context.Variables;
             var servicePrincipal = new ServicePrincipalAccount(variables);
-            var webAppName = variables.Get(SpecialVariables.Action.Azure.WebAppName);
+            string? webAppName = variables.Get(SpecialVariables.Action.Azure.WebAppName);
             if (webAppName == null)
                 throw new Exception("Web App Name must be specified");
-            var resourceGroupName = variables.Get(SpecialVariables.Action.Azure.ResourceGroupName);
+            string? resourceGroupName = variables.Get(SpecialVariables.Action.Azure.ResourceGroupName);
             if (resourceGroupName == null)
                 throw new Exception("resource group name must be specified");
-            var slotName = variables.Get(SpecialVariables.Action.Azure.WebAppSlot);
+            string? slotName = variables.Get(SpecialVariables.Action.Azure.WebAppSlot);
             var packageFileInfo = new FileInfo(variables.Get(TentacleVariables.CurrentDeployment.PackageFilePath));
 
             switch (packageFileInfo.Extension)
@@ -64,7 +63,7 @@ namespace Calamari.AzureAppService.Behaviors
                     throw new Exception("Unsupported archive type");
             }
 
-            var azureClient = servicePrincipal.CreateAzureClient(); 
+            var azureClient = servicePrincipal.CreateAzureClient();
             var webApp = await azureClient.WebApps.GetByResourceGroupAsync(resourceGroupName, webAppName);
             var targetSite = AzureWebAppHelper.GetAzureTargetSite(webAppName, slotName, resourceGroupName);
 
@@ -73,7 +72,7 @@ namespace Calamari.AzureAppService.Behaviors
             if (targetSite.HasSlot)
                 slotCreateTask = FindOrCreateSlot(webApp, targetSite);
 
-            var substitutionFeatures = new[]
+            string[]? substitutionFeatures = new[]
             {
                 KnownVariables.Features.ConfigurationTransforms,
                 KnownVariables.Features.StructuredConfigurationVariables,
@@ -85,16 +84,12 @@ namespace Calamari.AzureAppService.Behaviors
              * https://github.com/OctopusDeploy/Calamari/tree/master/source/Calamari.Common/Features/Behaviours
              */
 
-            var uploadPath = string.Empty;
+            string? uploadPath = string.Empty;
             if (substitutionFeatures.Any(featureName => context.Variables.IsFeatureEnabled(featureName)))
-            {
                 uploadPath = (await Archive.PackageArchive(context.StagingDirectory, context.CurrentDirectory))
                     .FullName;
-            }
             else
-            {
                 uploadPath = (await Archive.ConvertToAzureSupportedFile(packageFileInfo)).FullName;
-            }
 
             if (uploadPath == null)
                 throw new Exception("Package File Path must be specified");
@@ -102,18 +97,21 @@ namespace Calamari.AzureAppService.Behaviors
             // need to ensure slot is created as slot creds may be used
             if (targetSite.HasSlot)
                 await slotCreateTask;
-            var credential = await Auth.GetBasicAuthCreds(servicePrincipal, targetSite);
+
+            var publishingProfile = await PublishingProfile.GetPublishingProfile(targetSite, servicePrincipal);
+            string? credential = await Auth.GetBasicAuthCreds(servicePrincipal, targetSite);
             string token = await Auth.GetAuthTokenAsync(servicePrincipal);
-            
-            var webAppClient = new Microsoft.Azure.Management.WebSites.WebSiteManagementClient(new Uri(servicePrincipal.ResourceManagementEndpointBaseUri), new TokenCredentials(token))
-                { SubscriptionId = servicePrincipal.SubscriptionNumber};
+
+            var webAppClient = new WebSiteManagementClient(new Uri(servicePrincipal.ResourceManagementEndpointBaseUri),
+                    new TokenCredentials(token))
+                {SubscriptionId = servicePrincipal.SubscriptionNumber};
 
             var httpClient = webAppClient.HttpClient;
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credential);
-            
+
             Log.Info($"Uploading package to {targetSite.SiteAndSlot}");
 
-            await UploadZipAsync(httpClient, uploadPath, targetSite.ScmSiteAndSlot);
+            await UploadZipAsync(publishingProfile, httpClient, uploadPath, targetSite.ScmSiteAndSlot);
         }
 
         private async Task<IDeploymentSlot> FindOrCreateSlot(IWebApp client, TargetSite site)
@@ -135,7 +133,8 @@ namespace Calamari.AzureAppService.Behaviors
                 .CreateAsync();
         }
 
-        private async Task UploadZipAsync(HttpClient client, string uploadZipPath, string targetSite)
+        private async Task UploadZipAsync(PublishingProfile publishingProfile, HttpClient client, string uploadZipPath,
+            string targetSite)
         {
             Log.Verbose($"Path to upload: {uploadZipPath}");
             Log.Verbose($"Target Site: {targetSite}");
@@ -143,20 +142,17 @@ namespace Calamari.AzureAppService.Behaviors
             if (!new FileInfo(uploadZipPath).Exists)
                 throw new FileNotFoundException(uploadZipPath);
 
-            Log.Verbose($@"Publishing {uploadZipPath} to https://{targetSite}.scm.azurewebsites.net{Archive.UploadUrlPath}");
+            Log.Verbose($@"Publishing {uploadZipPath} to {publishingProfile.PublishUrl}{Archive.UploadUrlPath}");
 
             // The HttpClient default timeout is 100 seconds: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.timeout?view=net-5.0#remarks
             // This timeouts with even relatively small packages: https://octopus.zendesk.com/agent/tickets/69928
             // We'll set this to an hour for now, but we should probably implement some more advanced retry logic, similar to https://github.com/OctopusDeploy/Sashimi.AzureWebApp/blob/bbea36152b2fb531c2893efedf0330a06ae0cef0/source/Calamari/AzureWebAppBehaviour.cs#L70
             client.Timeout = TimeSpan.FromHours(1);
-            
-            var response = await client.PostAsync($@"https://{targetSite}.scm.azurewebsites.net{Archive.UploadUrlPath}",
+
+            var response = await client.PostAsync($@"{publishingProfile.PublishUrl}{Archive.UploadUrlPath}",
                 new StreamContent(new FileStream(uploadZipPath, FileMode.Open)));
 
-            if (!response.IsSuccessStatusCode)
-            {
-                throw new Exception(response.ReasonPhrase);
-            }
+            if (!response.IsSuccessStatusCode) throw new Exception(response.ReasonPhrase);
 
             Log.Verbose("Finished deploying");
         }

--- a/source/Calamari/PublishingProfile.cs
+++ b/source/Calamari/PublishingProfile.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Calamari.Azure;
+using Microsoft.Azure.Management.AppService.Fluent;
+using Microsoft.Azure.Management.AppService.Fluent.Models;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Authentication;
+using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
+using Microsoft.Rest;
+
+namespace Calamari.AzureAppService
+{
+    internal class PublishingProfile
+    {
+        public string Site { get; set; }
+
+        public string Password { get; set; }
+
+        public string Username { get; set; }
+
+        public string PublishUrl { get; set; }
+
+
+        public static async Task<PublishingProfile> GetPublishingProfile(TargetSite targetSite,
+            ServicePrincipalAccount account)
+        {
+            string mgmtEndpoint = account.ResourceManagementEndpointBaseUri;
+            var token = new TokenCredentials(await Auth.GetAuthTokenAsync(account));
+
+            var azureCredentials = new AzureCredentials(
+                    token,
+                    token,
+                    account.TenantId,
+                    new AzureKnownEnvironment(account.AzureEnvironment).AsAzureSDKEnvironment())
+                .WithDefaultSubscription(account.SubscriptionNumber);
+
+            var restClient = RestClient
+                .Configure()
+                .WithBaseUri(mgmtEndpoint)
+                .WithEnvironment(new AzureKnownEnvironment(account.AzureEnvironment).AsAzureSDKEnvironment())
+                .WithLogLevel(HttpLoggingDelegatingHandler.Level.Basic)
+                .WithCredentials(azureCredentials)
+                .Build();
+
+            var webAppClient = new WebSiteManagementClient(restClient)
+                {SubscriptionId = account.SubscriptionNumber};
+
+            var options = new CsmPublishingProfileOptions {Format = PublishingProfileFormat.WebDeploy};
+
+            await webAppClient.WebApps.GetWithHttpMessagesAsync(targetSite.ResourceGroupName, targetSite.Site);
+
+            using var publishProfileStream = targetSite.HasSlot
+                ? await webAppClient.WebApps.ListPublishingProfileXmlWithSecretsSlotAsync(targetSite.ResourceGroupName,
+                    targetSite.Site, options, targetSite.Slot)
+                : await webAppClient.WebApps.ListPublishingProfileXmlWithSecretsAsync(targetSite.ResourceGroupName,
+                    targetSite.Site,
+                    options);
+
+            using var streamReader = new StreamReader(publishProfileStream);
+            var document = XDocument.Parse(await streamReader.ReadToEndAsync());
+
+            var profile = (from el in document.Descendants("publishProfile")
+                where string.Compare(el.Attribute("publishMethod")?.Value, "MSDeploy",
+                    StringComparison.OrdinalIgnoreCase) == 0
+                select new PublishingProfile
+                {
+                    PublishUrl = $"https://{el.Attribute("publishUrl")?.Value}",
+                    Username = el.Attribute("userName")?.Value,
+                    Password = el.Attribute("userPWD")?.Value,
+                    Site = el.Attribute("msdeploySite")?.Value
+                }).FirstOrDefault();
+
+            if (profile == null) throw new Exception("Failed to retrieve publishing profile.");
+
+            return profile;
+        }
+    }
+}


### PR DESCRIPTION
This PR updates the deploys via the URL supplied in the AppService publishing profile instead of constructing the URL manually.

Affects https://github.com/OctopusDeploy/Issues/issues/6990