### PR TITLE
Bump Calamari.Common to 20.4.0

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -16,7 +16,7 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="20.3.8" />
+    <PackageReference Include="Calamari.Common" Version="20.4.0" />
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />


### PR DESCRIPTION
Rolling dependency changes through to keep things up to date, no functional changes in this Sashimi as it's not a "Run a Script" step.

(Version bump results from fix for OctopusDeploy/Issues#7050, which changed the way Bash Script parameters are handled)