### PR TITLE
Bumps Calamari.* to 18.1.7, Sashimi.* to 9.0.3, AzureScripting.* to 11.0.3 (Server 2021.1 stream)

### DIFF
--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="9.0.2" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="9.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.8" />
     <PackageReference Include="nunit" Version="3.13.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -16,7 +16,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="18.1.4" />
+    <PackageReference Include="Calamari.Common" Version="18.1.7" />
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.0" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.0" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.0" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="11.0.0" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.2" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="9.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,9 +23,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="2.1.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="9.0.2" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="9.0.2" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.2" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="9.0.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="9.0.3" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="11.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.1.

Upstream changes:
* OctopusDeploy/Calamari#805
* OctopusDeploy/Sashimi#130
* OctopusDeploy/Sashimi.AzureScripting#18

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177