### PR TITLE
Bumps Calamari.* to 19.4.10 and Sashimi.* to 14.0.3 (Server 2021.2 Stream)

### DIFF
--- a/.teamcity/octopus/main/buildtypes/PublishToFeedzIo.kt
+++ b/.teamcity/octopus/main/buildtypes/PublishToFeedzIo.kt
@@ -15,7 +15,7 @@ object PublishToFeedzIo : BuildType({
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             packages = "*.nupkg"
             serverUrl = "%InternalNuget.OctopusDependeciesFeedUrl%"
-            apiKey = "%nuGetPublish.apiKey%"
+            apiKey = "%FeedzIoApiKey%"
             args = "-Timeout 1200"
         }
     }

--- a/.teamcity/patches/buildTypes/Build.kts
+++ b/.teamcity/patches/buildTypes/Build.kts
@@ -50,13 +50,5 @@ changeBuildType(RelativeId("Build")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_AmazonLinux.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_AmazonLinux.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_AmazonLinux")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_CentOS.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_CentOS.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_CentOS")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_Debian.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_Debian.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_Debian")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_Fedora.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_Fedora.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_Fedora")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_OpenSUSE.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_OpenSUSE.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_OpenSUSE")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_Rhel.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_Rhel.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_Rhel")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_Ubuntu.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_Ubuntu.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_Ubuntu")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/NetcoreTesting_Windows.kts
+++ b/.teamcity/patches/buildTypes/NetcoreTesting_Windows.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("NetcoreTesting_Windows")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/PublishToFeedzIo.kts
+++ b/.teamcity/patches/buildTypes/PublishToFeedzIo.kts
@@ -23,12 +23,6 @@ changeBuildType(RelativeId("PublishToFeedzIo")) {
             args = "-Timeout 1200"
         }
     }
-    steps {
-        update<NuGetPublishStep>(0) {
-            clearConditions()
-            apiKey = "credentialsJSON:21016b86-e16b-4825-ab03-02ec2d979b7f"
-        }
-    }
 
     features {
         val feature1 = find<CommitStatusPublisher> {
@@ -38,14 +32,6 @@ changeBuildType(RelativeId("PublishToFeedzIo")) {
                     authType = personalToken {
                         token = "%commitStatusPublisher.apiKey%"
                     }
-                }
-            }
-        }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
                 }
             }
         }

--- a/.teamcity/patches/buildTypes/PublishToFeedzIo.kts
+++ b/.teamcity/patches/buildTypes/PublishToFeedzIo.kts
@@ -19,7 +19,7 @@ changeBuildType(RelativeId("PublishToFeedzIo")) {
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             packages = "*.nupkg"
             serverUrl = "%InternalNuget.OctopusDependeciesFeedUrl%"
-            apiKey = "%nuGetPublish.apiKey%"
+            apiKey = "%FeedzIoApiKey%"
             args = "-Timeout 1200"
         }
     }

--- a/.teamcity/patches/buildTypes/WindowsNetFxTesting_2012.kts
+++ b/.teamcity/patches/buildTypes/WindowsNetFxTesting_2012.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("WindowsNetFxTesting_2012")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/WindowsNetFxTesting_2012r2.kts
+++ b/.teamcity/patches/buildTypes/WindowsNetFxTesting_2012r2.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("WindowsNetFxTesting_2012r2")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/WindowsNetFxTesting_2016.kts
+++ b/.teamcity/patches/buildTypes/WindowsNetFxTesting_2016.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("WindowsNetFxTesting_2016")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/.teamcity/patches/buildTypes/WindowsNetFxTesting_2019.kts
+++ b/.teamcity/patches/buildTypes/WindowsNetFxTesting_2019.kts
@@ -26,13 +26,5 @@ changeBuildType(RelativeId("WindowsNetFxTesting_2019")) {
                 }
             }
         }
-        feature1.apply {
-            publisher = github {
-                githubUrl = "https://api.github.com"
-                authType = personalToken {
-                    token = "credentialsJSON:d2d6ff31-56f1-4893-a448-f7a517da6c88"
-                }
-            }
-        }
     }
 }

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -19,7 +19,7 @@
     <ProjectReference Include="..\Calamari\Calamari.csproj" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.ResourceManager.Resources" Version="1.0.0-preview.2" />
-    <PackageReference Include="Calamari.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Calamari.Tests.Shared" Version="14.0.3" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="nunit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -16,7 +16,7 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Calamari.Common" Version="19.4.6" />
+    <PackageReference Include="Calamari.Common" Version="19.4.10" />
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Websites" Version="3.1.1" />

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Octopus.Server.Tests.Extensibility" Version="14.0.5" />
-    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Tests.Shared" Version="14.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -23,10 +23,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octopus.Configuration" Version="4.0.0" />
-    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.1" />
-    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.1" />
-    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.0" />
-    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.1" />
+    <PackageReference Include="Sashimi.Azure.Accounts" Version="14.0.3" />
+    <PackageReference Include="Sashimi.Azure.Common" Version="14.0.3" />
+    <PackageReference Include="Sashimi.AzureScripting" Version="14.0.3" />
+    <PackageReference Include="Sashimi.Server.Contracts" Version="14.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Overview
This PR is one of a set of PRs to propagate a change to Calamari.Common through to Octopus Server 2021.2.

Upstream changes:
* OctopusDeploy/Calamari#808
* OctopusDeploy/Sashimi#133
* OctopusDeploy/Sashimi.AzureScripting#19

To fix Issues:
* OctopusDeploy/Issues#6794
* OctopusDeploy/Issues#7177