### PR TITLE
Caps max retry delay to 10 seconds and improves error handling

### DIFF
--- a/source/Calamari/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari/Behaviors/TargetDiscoveryBehaviour.cs
@@ -140,8 +140,8 @@ namespace Calamari.AzureAppService.Behaviors
                                 return TimeSpan.FromSeconds(int.Parse(retryAfter.First()));
                             }
                         }
-                        // Not a specific throttling exception, use exponential backoff
-                        return TimeSpan.FromSeconds(Math.Pow(2, retryAttempt));
+                        // Not a specific throttling exception, use exponential backoff with a maximum wait time of 10 seconds
+                        return TimeSpan.FromSeconds(Math.Min(10, Math.Pow(2, retryAttempt)));
                     },
                     (ex, delay, retryAttempt, context) =>
                     {

--- a/source/Calamari/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari/Behaviors/TargetDiscoveryBehaviour.cs
@@ -163,8 +163,8 @@ namespace Calamari.AzureAppService.Behaviors
                     fallbackValue: Enumerable.Empty<IDeploymentSlot>(),
                     onFallback: (exception, context) => Log.Verbose($"Could not list deployment slots for web app {webApp.Name} as it could no longer be found")
                 );
-
-            return webAppNotFoundPolicy.Wrap(retryPolicy).Execute(() =>
+            
+            return retryPolicy.Wrap(webAppNotFoundPolicy).Execute(() =>
             {
                 return webApp.DeploymentSlots.List();
             });


### PR DESCRIPTION
As a follow up to #30 this PR caps the maximum amount of time that we will wait between retries of azure calls during target discovery to 10 seconds. We need to balance allowing some time for Azure to catch up with our actions (particularly during automated tests where we have seen a fairly large number of Internal Server Error or Not Found errors that appear to be due to Azure not keeping up with the rate of us making web apps for testing) and not taking too long before failing and giving up on discovery.

This PR also adds better handling of NotFound responses from Azure when attempting to list deployment slots for a web app. Particularly in tests we could be attempting to discover a web app and it's slots that were created during a different test run and then have it removed from under our feet during our test. If we get a NotFound during listing deployment slots for a web app we'll log a message and continue on.