### PR TITLE
Adds prefix to name of discovered web app targets

### DIFF
--- a/source/Calamari/Behaviors/TargetDiscoveryBehaviour.cs
+++ b/source/Calamari/Behaviors/TargetDiscoveryBehaviour.cs
@@ -235,7 +235,7 @@ namespace Calamari.AzureAppService.Behaviors
         public static ServiceMessage CreateWebAppTargetCreationServiceMessage(string resourceGroupName, string webAppName, string accountId, string role, string? workerPoolId)
         {
             var parameters = new Dictionary<string, string?> {
-                    { "name", $"{resourceGroupName}/{webAppName}" },
+                    { "name", $"azure-web-app/{resourceGroupName}/{webAppName}" },
                     { "azureWebApp", webAppName },
                     { "azureResourceGroupName", resourceGroupName },
                     { "octopusAccountIdOrName", accountId },
@@ -253,7 +253,7 @@ namespace Calamari.AzureAppService.Behaviors
         public static ServiceMessage CreateWebAppDeploymentSlotTargetCreationServiceMessage(string resourceGroupName, string webAppName, string slotName, string accountId, string role, string? workerPoolId)
         {
             var parameters = new Dictionary<string, string?> {
-                    { "name", $"{resourceGroupName}/{webAppName}/{slotName}" },
+                    { "name", $"azure-web-app/{resourceGroupName}/{webAppName}/{slotName}" },
                     { "azureWebApp", webAppName },
                     { "azureResourceGroupName", resourceGroupName },
                     { "azureWebAppSlot", slotName },


### PR DESCRIPTION
When web app targets are discovered we currently give them a name in the format `{resourceGroup}/{webAppName}` for web apps and `{resourceGroup}/{webAppName}/{slotName}` for deployment slots. We think that there might be a potential for Octopus target name clashes if there were other targets in the future of different types within the same resource group that had the same name. For example in the future if there was an azure storage container target that was being used for a project alongside a web app it wouldn't be unreasonable for the user to name the web app and container the same thing, which could cause a name clash.

This PR adds a prefix `azure-web-app` to the front of the naming to help ensure that it is unique.