### PR TITLE
Fix file locking for parallel ZipDeploy deployments

### DIFF
--- a/source/Calamari.Tests/AppServiceBehaviorFixture.cs
+++ b/source/Calamari.Tests/AppServiceBehaviorFixture.cs
@@ -279,14 +279,14 @@ namespace Calamari.AzureAppService.Tests
                 return packageInfo;
             }
 
-            private void AddVariables(CommandTestBuilderContext context, string siteName = null)
+            private void AddVariables(CommandTestBuilderContext context)
             {
                 context.Variables.Add(AccountVariables.ClientId, clientId);
                 context.Variables.Add(AccountVariables.Password, clientSecret);
                 context.Variables.Add(AccountVariables.TenantId, tenantId);
                 context.Variables.Add(AccountVariables.SubscriptionId, subscriptionId);
                 context.Variables.Add("Octopus.Action.Azure.ResourceGroupName", resourceGroupName);
-                context.Variables.Add("Octopus.Action.Azure.WebAppName", siteName ?? site.Name);
+                context.Variables.Add("Octopus.Action.Azure.WebAppName", site.Name);
                 context.Variables.Add("Greeting", greeting);
                 context.Variables.Add(KnownVariables.Package.EnabledFeatures, KnownVariables.Features.SubstituteInFiles);
                 context.Variables.Add(PackageVariables.SubstituteInFilesTargets, "index.html");

--- a/source/Calamari/Behaviors/AzureAppServiceBehaviour.cs
+++ b/source/Calamari/Behaviors/AzureAppServiceBehaviour.cs
@@ -150,7 +150,7 @@ namespace Calamari.AzureAppService.Behaviors
             client.Timeout = TimeSpan.FromHours(1);
 
             var response = await client.PostAsync($@"{publishingProfile.PublishUrl}{Archive.UploadUrlPath}",
-                new StreamContent(new FileStream(uploadZipPath, FileMode.Open))
+                new StreamContent(new FileStream(uploadZipPath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 {
                     Headers = { ContentType = new MediaTypeHeaderValue("application/octet-stream") }
                 }


### PR DESCRIPTION
This PR introduces a fix for a problem where multiple parallel deployments executing on the same Deployment Target using the same source Zip package will fail because of a file locking issue. This prevents deploying to multiple targets in the same role of a `Deploy to an Azure App Service` step, unless you make it a rolling deployment.

## Before
Only one of the parallel deployment targets can succeed, others fail with a file locking issue
<img width="1681" alt="image" src="https://user-images.githubusercontent.com/730704/168228754-4ccc70ee-92e8-425a-af2e-1dd6d2e2cbae.png">

## After
Multiple deployments can run in parallel