### PR TITLE
Ensure AppService Deployment Targets' health check respects proxy settings

### DIFF
--- a/source/Calamari/Azure/AzureClient.cs
+++ b/source/Calamari/Azure/AzureClient.cs
@@ -1,5 +1,8 @@
 using System.Net;
 using System.Net.Http;
+using Azure.Core.Pipeline;
+using Azure.Identity;
+using Azure.ResourceManager;
 using Microsoft.Azure.Management.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 
@@ -22,6 +25,25 @@ namespace Calamari.Azure
                 .WithHttpClient(client)
                 .Authenticate(credentials)
                 .WithSubscription(servicePrincipal.SubscriptionNumber);
+        }
+
+        /// <summary>
+        /// Creates an ArmClient for the new Azure SDK, which replaces the older fluent libraries.
+        /// We should migrate to this SDK once it stabilises.
+        /// </summary>
+        /// <param name="servicePrincipal">Service Principal Account to use when connecting to Azure</param>
+        /// <returns></returns>
+        public static ArmClient CreateArmClient(this ServicePrincipalAccount servicePrincipal)
+        {
+            var environment = new AzureKnownEnvironment(servicePrincipal.AzureEnvironment).AsAzureArmEnvironment();
+
+            var httpClientTransport = new HttpClientTransport(new HttpClientHandler { Proxy = WebRequest.DefaultWebProxy });
+
+            var tokenCredentialOptions = new TokenCredentialOptions { Transport = httpClientTransport };
+            var credential = new ClientSecretCredential(servicePrincipal.TenantId, servicePrincipal.ClientId, servicePrincipal.Password, tokenCredentialOptions);
+
+            var armClientOptions = new ArmClientOptions() { Transport = httpClientTransport, Environment = environment };
+            return new ArmClient(credential, defaultSubscriptionId: servicePrincipal.SubscriptionNumber, armClientOptions);
         }
     }
 }

--- a/source/Calamari/Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari/Azure/AzureKnownEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Azure.ResourceManager;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 
 namespace Calamari.Azure
@@ -15,11 +16,11 @@ namespace Calamari.Azure
             if (string.IsNullOrEmpty(environment) || environment == "AzureCloud") // This environment name is defined in Sashimi.Azure.Accounts.AzureEnvironmentsListAction
                 Value = Global.Value;                                             // We interpret it as the normal Azure environment for historical reasons)
 
-            azureEnvironment = AzureEnvironment.FromName(Value) ??
+            azureSdkEnvironment = AzureEnvironment.FromName(Value) ??
                                throw new InvalidOperationException($"Unknown environment name {Value}");
         }
 
-        private readonly AzureEnvironment azureEnvironment;
+        private readonly AzureEnvironment azureSdkEnvironment;
         public string Value { get; }
 
         public static readonly AzureKnownEnvironment Global = new AzureKnownEnvironment("AzureGlobalCloud");
@@ -29,7 +30,18 @@ namespace Calamari.Azure
 
         public AzureEnvironment AsAzureSDKEnvironment()
         {
-            return azureEnvironment;
+            return azureSdkEnvironment;
         }
+
+        public ArmEnvironment AsAzureArmEnvironment() => ToArmEnvironment(Value);
+
+        private static ArmEnvironment ToArmEnvironment(string name) => name switch
+        {
+            "AzureGlobalCloud" => ArmEnvironment.AzurePublicCloud,
+            "AzureChinaCloud" => ArmEnvironment.AzureChina,
+            "AzureGermanCloud" => ArmEnvironment.AzureGermany,
+            "AzureUSGovernment" => ArmEnvironment.AzureGovernment,
+            _ => throw  new InvalidOperationException($"ARM Environment {name} is not a known Azure Environment name.")
+        };
     }
 }

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -16,6 +16,8 @@
     <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.ResourceManager.AppService" Version="1.0.0-beta.2" />
     <PackageReference Include="Calamari.Common" Version="21.1.0" />
     <PackageReference Include="Microsoft.Azure.Management.AppService.Fluent" Version="1.37.1" />
     <PackageReference Include="Microsoft.Azure.Management.Fluent" Version="1.37.1" />

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,6 +8,7 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <LangVersion>8.0</LangVersion>
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net461;net5.0</TargetFrameworks>

--- a/source/Sashimi.Tests/AzureWebAppHealthCheckActionHandlerFixtures.cs
+++ b/source/Sashimi.Tests/AzureWebAppHealthCheckActionHandlerFixtures.cs
@@ -1,7 +1,12 @@
 ﻿#nullable disable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
 using System.Threading.Tasks;
 using Calamari.Azure;
 using Calamari.AzureAppService;
+using Calamari.Common.Plumbing.Proxies;
 using Calamari.Tests.Shared;
 using FluentAssertions;
 using Microsoft.Azure.Management.AppService.Fluent;
@@ -9,7 +14,9 @@ using Microsoft.Azure.Management.ResourceManager.Fluent;
 using Microsoft.Azure.Management.ResourceManager.Fluent.Core;
 using NUnit.Framework;
 using Sashimi.Azure.Accounts;
+using Sashimi.Server.Contracts.ActionHandlers;
 using Sashimi.Tests.Shared.Server;
+using OperatingSystem = Microsoft.Azure.Management.AppService.Fluent.OperatingSystem;
 
 namespace Sashimi.AzureAppService.Tests
 {
@@ -111,6 +118,120 @@ namespace Sashimi.AzureAppService.Tests
                 })
                 .WithAssert(result => result.WasSuccessful.Should().BeFalse())
                 .Execute(false);
+        }
+    }
+
+    [TestFixture]
+    class AzureWebAppHealthCheckActionHandlerProxyFixture
+    {
+        private const string NonExistentProxyHostname = "non-existent-proxy.local";
+        private const int NonExistentProxyPort = 3128;
+
+        private IWebProxy? originalProxy;
+        private string originalProxyHost;
+        private string originalProxyPort;
+
+        private StringWriter errorStream;
+        private TextWriter originalConsoleErrorOut;
+
+        [SetUp]
+        public void SetUp()
+        {
+            SetLocalEnvironmentProxySettings(NonExistentProxyHostname, NonExistentProxyPort);
+            SetCiEnvironmentProxySettings(NonExistentProxyHostname, NonExistentProxyPort);
+            SetConsoleErrorOut();
+        }
+
+        /// <summary>
+        /// Configuring all the infrastructure required for a proper proxy test (with blocking certain addresses, proxy
+        /// server itself etc) is over the top for a test here. We can implicitly test that the proxy settings are being
+        /// picked up properly by setting a non-existent property, and ensuring that we fail with connectivity errors
+        /// *to the non-existent proxy* rather than a successful healthcheck directly to Azure.
+        /// </summary>
+        [Test]
+        public void ConfiguredProxy_IsUsedForHealthCheck()
+        {
+            // Arrange
+            var randomName = SdkContext.RandomResourceName(nameof(AzureWebAppHealthCheckActionHandlerFixtures), 60);
+            var clientId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionClientId);
+            var clientSecret = ExternalVariables.Get(ExternalVariable.AzureSubscriptionPassword);
+            var tenantId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionTenantId);
+            var subscriptionId = ExternalVariables.Get(ExternalVariable.AzureSubscriptionId);
+
+            // Act
+            var result = ActionHandlerTestBuilder.CreateAsync<AzureWebAppHealthCheckActionHandler, Program>()
+                .WithArrange(context =>
+                {
+                    context.Variables.Add(AccountVariables.SubscriptionId, subscriptionId);
+                    context.Variables.Add(AccountVariables.TenantId, tenantId);
+                    context.Variables.Add(AccountVariables.ClientId, clientId);
+                    context.Variables.Add(AccountVariables.Password, clientSecret);
+                    context.Variables.Add(SpecialVariables.Action.Azure.ResourceGroupName, randomName);
+                    context.Variables.Add(SpecialVariables.Action.Azure.WebAppName, randomName);
+                    context.Variables.Add(SpecialVariables.AccountType, AccountTypes.AzureServicePrincipalAccountType.ToString());
+                })
+                .Execute(assertWasSuccess: false);
+
+            // Assert
+            result.Outcome.Should().Be(ExecutionOutcome.Unsuccessful);
+
+            // This also operates differently locally vs on CI, so combine both StdErr and Calamari Log to get
+            // the full picture
+            var windowsNetFxDnsError = "The remote name could not be resolved: 'non-existent-proxy.local'";
+            var ubuntuDnsError = "Resource temporarily unavailable (non-existent-proxy.local:3128)";
+            var generalLinuxDnsError = "Name or service not known (non-existent-proxy.local:3128)";
+            var windowsDotNetDnsError = "No such host is known. (non-existent-proxy.local:3128)";
+
+            var calamariOutput = result.FullLog + errorStream;
+            calamariOutput.Should().ContainAny(windowsDotNetDnsError, ubuntuDnsError,generalLinuxDnsError, windowsNetFxDnsError);
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            RestoreLocalEnvironmentProxySettings();
+            RestoreCiEnvironmentProxySettings();
+            RestoreConsoleErrorOut();
+        }
+
+        private void SetConsoleErrorOut()
+        {
+            originalConsoleErrorOut = Console.Error;
+            errorStream = new StringWriter();
+            Console.SetError(errorStream);
+        }
+
+        private void SetLocalEnvironmentProxySettings(string hostname, int port)
+        {
+            originalProxy = WebRequest.DefaultWebProxy;
+
+            var proxySettings = new UseCustomProxySettings(hostname, port, null!, null!).CreateProxy().Value;
+            WebRequest.DefaultWebProxy = proxySettings;
+        }
+
+        private void SetCiEnvironmentProxySettings(string hostname, int port)
+        {
+            originalProxyHost = Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost);
+            originalProxyPort = Environment.GetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort);
+
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, hostname);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, $"{port}");
+        }
+
+        private void RestoreConsoleErrorOut()
+        {
+            Console.SetError(originalConsoleErrorOut);
+        }
+
+        private void RestoreLocalEnvironmentProxySettings()
+        {
+            WebRequest.DefaultWebProxy = originalProxy;
+        }
+
+        private void RestoreCiEnvironmentProxySettings()
+        {
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyHost, originalProxyHost);
+            Environment.SetEnvironmentVariable(EnvironmentVariables.TentacleProxyPort, originalProxyPort);
         }
     }
 }


### PR DESCRIPTION
(Cherry-Pick of 07785f5b for Server Stream 2022.1)

* Ensure HealthCheck respects configured proxy settings
* Add test to ensure Health Check respects proxy settings
* Ensure Proxy test works on both CI and locally
* Fixes another small difference in testing between CI and local
* More tweaks to test for cross-OS assertion
* Fix up refactor in AppServiceBehaviourFixture
* Simplify Proxy test code