### PR TITLE
Suppress NuGet pack warning

### DIFF
--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -8,6 +8,7 @@
     <OutputType>Exe</OutputType>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64;linux-arm;linux-arm64</RuntimeIdentifiers>
     <LangVersion>8.0</LangVersion>
+    <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
     <TargetFrameworks>net461;net5.0</TargetFrameworks>


### PR DESCRIPTION
#35 intentionally added a `-beta` version of an AzureSDK library, but now the build is failing to pack the NuGet package because of it. Adding a suppression temporarily until the library is out of beta.