### PR TITLE
Fix HealthCheck auth endpoint for alternate Azure Clouds

### DIFF
--- a/source/Calamari.Tests/AzureClientFixture.cs
+++ b/source/Calamari.Tests/AzureClientFixture.cs
@@ -33,7 +33,7 @@ namespace Calamari.AzureAppService.Tests
         [TestCase("AzureChinaCloud", "https://management.chinacloudapi.cn")]
         [TestCase("AzureGermanCloud", "https://management.microsoftazure.de")]
         [TestCase("AzureUSGovernment", "https://management.usgovcloudapi.net")]
-        public void AzureClientOptions_APiCall_UsesCorrectEndpointsForRegions(string azureCloud, string expectedManagementEndpoint)
+        public void AzureClientOptions_ApiCall_UsesCorrectEndpointsForRegions(string azureCloud, string expectedManagementEndpoint)
         {
             // Arrange
             var servicePrincipalAccount = GetAccountFor(azureCloud);

--- a/source/Calamari.Tests/AzureClientFixture.cs
+++ b/source/Calamari.Tests/AzureClientFixture.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Azure.ResourceManager;
+using Calamari.Azure;
+using NUnit.Framework;
+
+namespace Calamari.AzureAppService.Tests
+{
+    public class AzureClientFixture
+    {
+        [Test]
+        [TestCase("", "https://login.microsoftonline.com/")]
+        [TestCase("AzureCloud", "https://login.microsoftonline.com/")]
+        [TestCase("AzureGlobalCloud", "https://login.microsoftonline.com/")]
+        [TestCase("AzureChinaCloud", "https://login.chinacloudapi.cn/")]
+        [TestCase("AzureGermanCloud", "https://login.microsoftonline.de/")]
+        [TestCase("AzureUSGovernment", "https://login.microsoftonline.us/")]
+        public void AzureClientOptions_IdentityAuth_UsesCorrectEndpointsForRegions(string azureCloud, string expectedAuthorityHost)
+        {
+            // Arrange
+            var servicePrincipalAccount = GetAccountFor(azureCloud);
+
+            // Act
+            var (_, tokenCredentialOptions) = servicePrincipalAccount.GetArmClientOptions();
+
+            // Assert
+            Assert.AreEqual(new Uri(expectedAuthorityHost), tokenCredentialOptions.AuthorityHost);
+        }
+
+        [Test]
+        [TestCase("", "https://management.azure.com")]
+        [TestCase("AzureCloud", "https://management.azure.com")]
+        [TestCase("AzureGlobalCloud", "https://management.azure.com")]
+        [TestCase("AzureChinaCloud", "https://management.chinacloudapi.cn")]
+        [TestCase("AzureGermanCloud", "https://management.microsoftazure.de")]
+        [TestCase("AzureUSGovernment", "https://management.usgovcloudapi.net")]
+        public void AzureClientOptions_APiCall_UsesCorrectEndpointsForRegions(string azureCloud, string expectedManagementEndpoint)
+        {
+            // Arrange
+            var servicePrincipalAccount = GetAccountFor(azureCloud);
+
+            // Act
+            var (armClientOptions, _) = servicePrincipalAccount.GetArmClientOptions();
+
+            // Assert
+            Assert.AreEqual(new Uri(expectedManagementEndpoint), armClientOptions.Environment.Value.Endpoint);
+        }
+
+        private ServicePrincipalAccount GetAccountFor(string azureCloud)
+        {
+            return new ServicePrincipalAccount("123-456-789",
+                "clientId",
+                "tenantId",
+                "p@ssw0rd",
+                azureCloud,
+                null,
+                null);
+        }
+    }
+}

--- a/source/Calamari/Azure/AzureKnownEnvironment.cs
+++ b/source/Calamari/Azure/AzureKnownEnvironment.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Azure.Identity;
 using Azure.ResourceManager;
 using Microsoft.Azure.Management.ResourceManager.Fluent;
 
@@ -42,6 +43,17 @@ namespace Calamari.Azure
             "AzureGermanCloud" => ArmEnvironment.AzureGermany,
             "AzureUSGovernment" => ArmEnvironment.AzureGovernment,
             _ => throw  new InvalidOperationException($"ARM Environment {name} is not a known Azure Environment name.")
+        };
+
+        public Uri GetAzureAuthorityHost() => ToAzureAuthorityHost(Value);
+
+        private static Uri ToAzureAuthorityHost(string name) => name switch
+        {
+            "AzureGlobalCloud" => AzureAuthorityHosts.AzurePublicCloud,
+            "AzureChinaCloud" => AzureAuthorityHosts.AzureChina,
+            "AzureGermanCloud" => AzureAuthorityHosts.AzureGermany,
+            "AzureUSGovernment" => AzureAuthorityHosts.AzureGovernment,
+            _ => throw new InvalidOperationException($"ARM Environment {name} is not a known Azure Environment name.")
         };
     }
 }


### PR DESCRIPTION
# Background
We recently fixed [a problem where the configured proxy was not respected](https://github.com/OctopusDeploy/Issues/issues/7544) when performing Azure App Service target health checks. This involved using a new version of the Azure SDK, because the previous version was causing the bug and Microsoft will not fix it.

In doing so, we introduced OctopusDeploy/Issues#7663, which causes health-checks on Azure Clouds other than Azure Public Cloud to fail. This is because the AuthorityHost for the login process had not been correctly plumbed through to the new SDK client, and it's very hard for people outside those Azure Cloud regions to get access to test against them.

# Result
This PR ensures that the AuthorityHost is correctly plumbed through to the SDK Client for the login process, which when adopted into Octopus Server will remediate OctopusDeploy/Issues#7663