### PR TITLE
Bumping to .Net 6

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "5.0.100",
+    "version": "6.0.0",
     "rollForward": "latestFeature"
   }
 }

--- a/source/Sashimi.Tests/Sashimi.Tests.csproj
+++ b/source/Sashimi.Tests/Sashimi.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Sashimi.AzureAppService.Tests</RootNamespace>
     <AssemblyName>Sashimi.AzureAppService.Tests</AssemblyName>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/source/Sashimi/Sashimi.csproj
+++ b/source/Sashimi/Sashimi.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Sashimi.AzureAppService</AssemblyName>
     <RootNamespace>Sashimi.AzureAppService</RootNamespace>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Nullable>enable</Nullable>
     <OutputPath>bin\</OutputPath>


### PR DESCRIPTION
Bumping from .Net 5 to .Net 6 prior to pulling into Octopus Server. Tested locally with release below
![image](https://user-images.githubusercontent.com/101079287/179660417-b13ce817-d248-418b-964b-fa01b77e1f3e.png)
Deployed to - https://isaac-web-app-net6.azurewebsites.net/WeatherForecast 
