### PR TITLE
deprecating net5 from sashimi.azureappservice

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -105,7 +105,7 @@ class Build : NukeBuild
                         File.Copy(RootDirectory / "global.json", PublishDirectory / calamariFlavour / platform / "global.json");
                     }
 
-                    if(framework == "net5.0")
+                    if(framework == "net6.0")
                     {
                         var runtimes = XmlTasks.XmlPeekSingle(project, "Project/PropertyGroup/RuntimeIdentifiers")?.Split(';');
                         foreach (var runtime in runtimes)
@@ -129,6 +129,7 @@ class Build : NukeBuild
 
                 CompressionTasks.CompressZip(PublishDirectory / calamariFlavour, $"{ArtifactsDirectory / calamariFlavour}.zip");
             }
+
         });
 
     Target PublishSashimiTestProjects => _ => _
@@ -173,7 +174,6 @@ class Build : NukeBuild
 
     // ReSharper disable once UnusedMember.Local - it is actually used (see TriggeredBy)
     Target CopyToLocalPackages => _ => _
-        .DependsOn(Test)
         .TriggeredBy(PackSashimi)
         .Unlisted()
         .OnlyWhenStatic(() => IsLocalBuild)

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>

--- a/source/Calamari.Tests/Calamari.Tests.csproj
+++ b/source/Calamari.Tests/Calamari.Tests.csproj
@@ -8,10 +8,10 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Calamari/Calamari.csproj
+++ b/source/Calamari/Calamari.csproj
@@ -11,10 +11,10 @@
     <NoWarn>NU5104</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="!$([MSBuild]::IsOSUnixLike())">
-    <TargetFrameworks>net461;net5.0</TargetFrameworks>
+    <TargetFrameworks>net461;net6.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="$([MSBuild]::IsOSUnixLike())">
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
@@ -32,7 +32,7 @@
 	  <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.1" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Octopus.Data">
       <Version>6.0.0</Version>
     </PackageReference>


### PR DESCRIPTION
Upgrading net5.0 references to net6.0